### PR TITLE
update java dependency to support node v6

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "glob": "^5.0.15",
     "handlebars": "^4.0.3",
     "immutable": "^3.3.0",
-    "java": "^0.6.0",
+    "java": "^0.7.0",
     "lodash": "^3.10.1",
     "ls-archive": "^1.0.3",
     "mkdirp": "^0.5.0",


### PR DESCRIPTION
`nan` should be updated to support node v6 (otherwise build fails). `ts-java` depends on `nan` through `java`, which uses new `nan` in its new version.

Passes all tests locally.
